### PR TITLE
feat: redo of multithreading support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Ubuntu
 
 ```bash
 sudo apt update
-sudo apt install git python3-dev python3-pip build-essential libagg-dev libpotrace-dev pkg-config
+sudo apt install git python3-dev python3-pip build-essential libagg-dev libpotrace-dev pkg-config ffmpeg
 ```
 
 CentOS/RedHat
@@ -37,6 +37,7 @@ UNIX
 ```bash
 virtualenv env
 source env/bin/activate
+pip install -r requirements.txt
 ```
 
 Windows
@@ -44,6 +45,7 @@ Windows
 ```bash
 virtualenv --python C:\Path\To\Python\python.exe env
 .\env\Scripts\activate
+pip install -r requirements.txt
 ```
 
 ## Running the Program
@@ -63,7 +65,7 @@ python mediagrapher.py --help
 Output:
 
 ```bash
-usage: MediaGrapher [-h] [-o OUTPUT] [-a {Canny,Sobel}] [-t LOW HIGH] url
+usage: MediaGrapher [-h] [-o OUTPUT] [-a {Canny,Sobel}] [-t LOW HIGH] [-p threads] url
 
 Command-line interface for graphing images and videos.
 
@@ -73,13 +75,15 @@ positional arguments:
 options:
   -h, --help            show this help message and exit
   -o OUTPUT, --output OUTPUT
-                        Output file name.
+                        Output file name. (default name: output)
   -a {Canny,Sobel}, --algorithm {Canny,Sobel}
-                        Edge detection algorithm.
+                        Edge detection algorithm. (default algorithm: Canny)
   -t LOW HIGH, --thresholds LOW HIGH
                         Thresholds for the Canny edge detection algorithm. (default: 30, 200)
+  -p THREADS, --threads THREADS (range from 1 to MAX_THREADS)
+                        Number of threads utilized on the CPU. (default: MAX_THREADS)
 ```
 
 ## Credits
 
-This project is heavily influenced by the following ![GitHub repository](https://github.com/kevinjycui/DesmosBezierRenderer).
+This project is heavily influenced by the following [GitHub repository](https://github.com/kevinjycui/DesmosBezierRenderer).

--- a/mediagrapher.py
+++ b/mediagrapher.py
@@ -32,7 +32,6 @@ parser.add_argument('-p', '--threads', type=int, choices=range(1, MAX_THREADS+1)
                     help="Number of threads utilized on the CPU. (default: MAX_THREADS)")
 args = parser.parse_args()
 
-THREADS = args.threads
 URL = args.url
 OUTPUT = args.output
 ALGORITHM = args.algorithm

--- a/mediagrapher.py
+++ b/mediagrapher.py
@@ -14,6 +14,7 @@ from mediagrapher.media.image import ImageMedia
 from mediagrapher.grapher.matplotlib_grapher import MatplotlibGrapher
 
 ALLOWED_ALGORITHMS = ["Canny", "Sobel"]
+MAX_THREADS = os.cpu_count()
 
 # Argument Parser
 parser = argparse.ArgumentParser(
@@ -27,14 +28,16 @@ parser.add_argument('-a', '--algorithm', type=str,
                     choices=ALLOWED_ALGORITHMS, default="Canny", help="Edge detection algorithm.")
 parser.add_argument('-t', '--thresholds', type=int, nargs=2, default=(30, 200), metavar=('LOW', 'HIGH'),
                     help="Thresholds for the Canny edge detection algorithm. (default: 30, 200)")
-
+parser.add_argument('-p', '--threads', type=int, choices=range(1, MAX_THREADS+1), default=MAX_THREADS,
+                    help="Number of threads utilized on the CPU. (default: MAX_THREADS)")
 args = parser.parse_args()
 
+THREADS = args.threads
 URL = args.url
 OUTPUT = args.output
 ALGORITHM = args.algorithm
 THRESHOLDS = args.thresholds
-
+THREADS = args.threads
 
 def get_media(url: str) -> tuple:
     """
@@ -187,7 +190,7 @@ def get_video_metadata(video_path):
         return None
 
 
-def process_video(video_path: str, frames_folder: str, output_filename: str):
+def process_video(video_path: str, frames_folder: str, output_filename: str, threads: int):
     """
     Process a video by extracting frames, applying image processing algorithms to each frame, and combining the processed frames into a new video.
 
@@ -198,6 +201,7 @@ def process_video(video_path: str, frames_folder: str, output_filename: str):
         algorithm (str, optional): The image processing algorithm to apply to each frame. Defaults to "Canny".
         thresholds (tuple, optional): The thresholds to be used by the image processing algorithm. Defaults to (30, 150).
     """
+    print(f"Utilizing {threads} threads...")
     print("Getting video metadata...")
     metadata = get_video_metadata(video_path)
 
@@ -208,7 +212,7 @@ def process_video(video_path: str, frames_folder: str, output_filename: str):
     print("Processing frames...")
 
     total_frames = int(metadata['total_frames'])
-    Parallel(n_jobs=-1)(delayed(process_frame)(frame, frames_folder, output_filename) for frame in trange(1, total_frames + 1))
+    Parallel(n_jobs=threads)(delayed(process_frame)(frame, frames_folder, output_filename) for frame in trange(1, total_frames + 1))
 
     print("Combining frames...")
     combine_video_frames(video_path, os.path.join(


### PR DESCRIPTION
Edit readme how to use new arg in CLI
Edit readme to install ffmpeg and requirements.txt

# Pull Request

<!-- PR Template from ColleagueApp/colleague -->

## Describe your changes
- Edits to Readme:
   - `ffmpeg` to system dependencies.
   - `pip install -r requirements.txt` to project dependencies.
   - instructions for new CLI arg `-p threads`.

- New optional CLI argument `-p threads` allowing user to choose how many CPU threads are utilized during video processing:

```py
MAX_THREADS = os.cpu_count()
parser.add_argument('-p', '--threads', type=int, choices=range(1, MAX_THREADS+1), default=MAX_THREADS,
                    help="Number of threads utilized on the CPU. (default: MAX_THREADS)")
```
`threads` is an int ranged from 1 to `MAX_THREADS`.

## Issue ticket number and link
Resolves #25 
## Topic

- [x] Enhancement / New Feature
- [ ] Bug Fix
- [x] Documentation
- [ ] Test
- [ ] Breaking Change

## Supporting Docs
Testing '-p threads' arg, my machine is capable of 16 threads. 
Testing with 0:
![Screenshot 2024-01-20 213211](https://github.com/jedrm/MediaGrapher/assets/78616243/3646b922-bd08-47a1-94d3-ff274a7aa5b7)
We can see that the CLI ensures only correct input from `1-MAX_THREADS` is accepted. 
