### PR TITLE
bug: process_video() wasn't passing arg threads

### DIFF
--- a/mediagrapher.py
+++ b/mediagrapher.py
@@ -258,7 +258,7 @@ def main():
         print("Done.")
     elif media_type == "video":
         print("Processing video...")
-        process_video(media, os.path.join("input", "frames"), OUTPUT)
+        process_video(media, os.path.join("input", "frames"), OUTPUT, THREADS)
     else:
         print("Error: Could not process media.")
 


### PR DESCRIPTION
# Pull Request

<!-- PR Template from ColleagueApp/colleague -->

## Describe your changes

`process_video()` didn't have `THREADS` in its args, so the CLI thinks that by leaving that arg blank it returns an error message that it is required when it actually is optional:
![image](https://github.com/jedrm/MediaGrapher/assets/78616243/b0a995cc-afdd-4fe2-8d49-38d336cd8b65)

After the fix:
![image](https://github.com/jedrm/MediaGrapher/assets/78616243/88db2219-5286-4abc-bb69-236ad0510ea3)
 We see the CLI clearly auto-selects `MAX_THREADS`.

## Issue ticket number and link

## Topic

- [ ] Enhancement / New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Test
- [ ] Breaking Change

## Supporting Docs

Attach any supporting documents for your pull request such as images, code snippets, etc.
