### PR TITLE
GUI: Threads Parameter

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -23,6 +23,7 @@ from superqt import QLabeledRangeSlider
 ALLOWED_ALGORITHMS = ["Canny", "Sobel"]
 MAX_THREADS = os.cpu_count()
 
+
 class MainWindow(QMainWindow):
     """
     The main window of the MediaGrapher application.
@@ -144,7 +145,7 @@ class MainWindow(QMainWindow):
         Returns:
             None
         """
-        self.algo_combo_box = QComboBox()
+        self.algo_combo_box = QComboBox() #QCompleter can be used if there ends up being a lot of algorithms to select from.
         self.algo_combo_box.addItems(ALLOWED_ALGORITHMS)
         algo_label = QLabel("Algorithm: ")
         algo_label.setBuddy(self.algo_combo_box)
@@ -196,9 +197,10 @@ class MainWindow(QMainWindow):
             None
         """
         self.threads_combo_box = QComboBox()
-        self.threads_combo_box.addItems([str(i) for i in range(1, MAX_THREADS+1)])
-        self.threads_combo_box.setCurrentIndex(MAX_THREADS-1)  # Set default choice to MAX_THREADS
-        self.threads_combo_box.view().setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+        self.threads_combo_box.addItems(
+            [str(i) for i in range(1, MAX_THREADS+1)])
+        self.threads_combo_box.setCurrentIndex(
+            MAX_THREADS-1)  # Set default choice to MAX_THREADS
         threads_label = QLabel("Number of CPU Threads: ")
         threads_label.setBuddy(self.threads_combo_box)
         threads_layout = QHBoxLayout()
@@ -272,7 +274,8 @@ class MainWindow(QMainWindow):
                          ] if self.algo_combo_box.currentText() else []
             threshold_flag = ["-t", self.threshold[0],
                               self.threshold[1]] if self.threshold else []
-            threads_flag = ["-p", self.threads_combo_box.currentText()] if self.threads_combo_box.currentText() else []
+            threads_flag = ["-p", self.threads_combo_box.currentText()
+                            ] if self.threads_combo_box.currentText() else []
 
             # subprocess.run(["python", "mediagrapher.py", self.input_field.text()]+ output_flag + algo_flag + threshold_flag + threads_flag)
             self.process.start("python", ["mediagrapher.py", self.input_field.text(

--- a/gui.py
+++ b/gui.py
@@ -4,6 +4,7 @@ GUI for MediaGrapher
 
 
 import sys
+import os
 # import subprocess
 
 # NOTE: Some imports are for commented out code (Settings Window)
@@ -14,11 +15,13 @@ from PyQt6.QtWidgets import (QHBoxLayout, QComboBox, QLineEdit, QTextEdit, QAppl
                              QPushButton, QVBoxLayout, QWidget)
 from superqt import QLabeledRangeSlider
 
-
 # Setting Window (Additional Imports)
 # from PyQt6 import QtWidgets
 # from PyQt6.QtGui import QResizeEvent
 # from PyQt6.QtWidgets import (QMenu, QDialog, QRadioButton, QDialogButtonBox, QGroupBox)
+
+ALLOWED_ALGORITHMS = ["Canny", "Sobel"]
+MAX_THREADS = os.cpu_count()
 
 class MainWindow(QMainWindow):
     """
@@ -88,6 +91,7 @@ class MainWindow(QMainWindow):
         self.init_menu()
         self.algorithm_parameters()
         self.thresholds_parameter()
+        self.threads_parameter()
         self.init_input_field()
         self.init_script_button()
 
@@ -141,7 +145,7 @@ class MainWindow(QMainWindow):
             None
         """
         self.algo_combo_box = QComboBox()
-        self.algo_combo_box.addItems(["Canny", "Sobel"])
+        self.algo_combo_box.addItems(ALLOWED_ALGORITHMS)
         algo_label = QLabel("Algorithm: ")
         algo_label.setBuddy(self.algo_combo_box)
         algo_layout = QHBoxLayout()
@@ -175,6 +179,33 @@ class MainWindow(QMainWindow):
                           for value in self.threshold_slider.value()]
 
         self.layout.addLayout(threshold_layout)
+
+    def threads_parameter(self):
+        """
+        Creates a parameter for selecting the number of CPU threads to be used.
+
+        This method creates a QComboBox widget that allows the user to select the number of CPU threads to be used.
+        The available options range from 1 to MAX_THREADS.
+        The default choice is set to MAX_THREADS.
+        The widget is added to the layout of the GUI.
+
+        Parameters:
+            None
+
+        Returns:
+            None
+        """
+        self.threads_combo_box = QComboBox()
+        self.threads_combo_box.addItems([str(i) for i in range(1, MAX_THREADS+1)])
+        self.threads_combo_box.setCurrentIndex(MAX_THREADS-1)  # Set default choice to MAX_THREADS
+        self.threads_combo_box.view().setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+        threads_label = QLabel("Number of CPU Threads: ")
+        threads_label.setBuddy(self.threads_combo_box)
+        threads_layout = QHBoxLayout()
+        threads_layout.addWidget(threads_label)
+        threads_layout.addWidget(self.threads_combo_box)
+        self.layout.addLayout(threads_layout)
+
 
     def init_input_field(self):
         """
@@ -241,10 +272,11 @@ class MainWindow(QMainWindow):
                          ] if self.algo_combo_box.currentText() else []
             threshold_flag = ["-t", self.threshold[0],
                               self.threshold[1]] if self.threshold else []
+            threads_flag = ["-p", self.threads_combo_box.currentText()] if self.threads_combo_box.currentText() else []
 
-            # subprocess.run(["python", "mediagrapher.py", self.input_field.text()]+ output_flag + algo_flag + threshold_flag)
+            # subprocess.run(["python", "mediagrapher.py", self.input_field.text()]+ output_flag + algo_flag + threshold_flag + threads_flag)
             self.process.start("python", ["mediagrapher.py", self.input_field.text(
-            )] + output_flag + algo_flag + threshold_flag)
+            )] + output_flag + algo_flag + threshold_flag + threads_flag)
 
             # Just to prevent accidentally running multiple times
             # Disable the button when process starts, and enable it when it finishes


### PR DESCRIPTION
# Pull Request

<!-- PR Template from ColleagueApp/colleague -->

## Describe your changes
Added threads parameter to MediaGrapher GUI

## Issue ticket number and link

Resolves https://github.com/jedrm/MediaGrapher/issues/38

## Topic

- [X] Enhancement / New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Test
- [ ] Breaking Change

## Supporting Docs

Terminal output shows that 6 threads are being used, as selected in the GUI: ``Utilizing 6 threads...``

```bash
[youtube] Extracting URL: https://www.youtube.com/watch?v=dyVaHHn7j5Y&ab_channel=ItzSlashy
[youtube] dyVaHHn7j5Y: Downloading webpage
[youtube] dyVaHHn7j5Y: Downloading ios player API JSON
[youtube] dyVaHHn7j5Y: Downloading android player API JSON
[youtube] dyVaHHn7j5Y: Downloading m3u8 information
[info] dyVaHHn7j5Y: Downloading 1 format(s): 22
[download] Destination: input/input.mp4
[download] 100% of    9.02MiB in 00:00:00 at 10.88MiB/s
Processing video...   
Utilizing 6 threads...
Getting video metadata...
Extracting frames...
Processing frames...
```
![MediaGrapher  - Threads](https://github.com/jedrm/MediaGrapher/assets/94929327/e07085c4-b8f7-42e9-aa30-07378b394697)


